### PR TITLE
Minor refactor for easier serialization

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -54,7 +54,7 @@ public class MongoDbChangeEventContext implements Serializable {
   private final String shadowCollection;
   private final Object documentId;
   private final Document shadowDocument;
-  private final Document dataDocument;
+  private final String jsonStringData;
   private final boolean isDeleteEvent;
   private final Document timestampDoc;
 
@@ -134,7 +134,7 @@ public class MongoDbChangeEventContext implements Serializable {
     // Determine event types
     this.isDeleteEvent = isDeleteEvent(changeEvent);
 
-    this.dataDocument = generateDataDocument();
+    this.jsonStringData = dataAsJsonString();
     this.shadowDocument = generateShadowDocument();
   }
 
@@ -159,20 +159,12 @@ public class MongoDbChangeEventContext implements Serializable {
     return shadowDoc;
   }
 
-  public Document generateDataDocument() throws JsonProcessingException {
+  public String dataAsJsonString() throws JsonProcessingException {
     if (isDeleteEvent) {
       return null;
     }
     JsonNode jsonNode = this.getChangeEvent();
-    String jsonString = OBJECT_MAPPER.writeValueAsString(jsonNode);
-    Document rawDoc;
-    try {
-      rawDoc = Document.parse(Document.parse(jsonString).get(DATA_COL).toString());
-    } catch (Exception ex) {
-      rawDoc = (Document) Document.parse(jsonString).get(DATA_COL);
-    }
-    rawDoc.put(MongoDbChangeEventContext.DOC_ID_COL, documentId);
-    return rawDoc;
+    return OBJECT_MAPPER.writeValueAsString(jsonNode);
   }
 
   public JsonNode getChangeEvent() {
@@ -199,8 +191,8 @@ public class MongoDbChangeEventContext implements Serializable {
     return shadowDocument;
   }
 
-  public Document getDataDocument() {
-    return dataDocument;
+  public String getDataAsJsonString() {
+    return jsonStringData;
   }
 
   public Document getTimestampDoc() {

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -15,12 +15,18 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import static com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext.DATA_COL;
+
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import java.util.Set;
 import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utils used by the Datastream-mongodb-to-mongodb pipeline. */
 public final class Utils {
+  private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
   public static void removeTableRowFields(Document doc, Set<String> ignoreFields) {
     for (String ignoreField : ignoreFields) {
       doc.remove(ignoreField);
@@ -34,5 +40,18 @@ public final class Utils {
     long s2 = ts2.getLong(MongoDbChangeEventContext.TIMESTAMP_SECONDS_COL);
     int n2 = ts2.getInteger(MongoDbChangeEventContext.TIMESTAMP_NANOS_COL);
     return s1 > s2 || (s1 == s2 && n1 > n2);
+  }
+
+  public static Document jsonToDocument(String jsonString, Object documentId) {
+    LOG.info("Converting json string {} for id {} to Document.", jsonString, documentId);
+    Document rawDoc;
+    try {
+      rawDoc = Document.parse(Document.parse(jsonString).get(DATA_COL).toString());
+    } catch (Exception ex) {
+      LOG.info("Document parsing failed due to {}, try casting.", ex.getMessage());
+      rawDoc = (Document) Document.parse(jsonString).get(DATA_COL);
+    }
+    rawDoc.put(MongoDbChangeEventContext.DOC_ID_COL, documentId);
+    return rawDoc;
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -43,12 +43,12 @@ public final class Utils {
   }
 
   public static Document jsonToDocument(String jsonString, Object documentId) {
-    LOG.info("Converting json string {} for id {} to Document.", jsonString, documentId);
     Document rawDoc;
     try {
       rawDoc = Document.parse(Document.parse(jsonString).get(DATA_COL).toString());
     } catch (Exception ex) {
-      LOG.info("Document parsing failed due to {}, try casting.", ex.getMessage());
+      LOG.info(
+          "Document parsing for {} failed due to {}, try casting.", jsonString, ex.getMessage());
       rawDoc = (Document) Document.parse(jsonString).get(DATA_COL);
     }
     rawDoc.put(MongoDbChangeEventContext.DOC_ID_COL, documentId);

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -92,7 +92,9 @@ public class ProcessChangeEventFnTest {
     mockShadowDocNewer =
         new Document(MongoDbChangeEventContext.TIMESTAMP_COL, mockTimestampDocNewer);
     mockDataDoc =
-        new Document(MongoDbChangeEventContext.DOC_ID_COL, DOC_ID).append("field", "value");
+        new Document(
+            "data",
+            new Document(MongoDbChangeEventContext.DOC_ID_COL, DOC_ID).append("field", "value"));
     mockShadowDocElement =
         new Document(MongoDbChangeEventContext.SHADOW_DOC_ID_COL, DOC_ID)
             .append(MongoDbChangeEventContext.TIMESTAMP_COL, mockTimestampDocNewer);
@@ -114,7 +116,7 @@ public class ProcessChangeEventFnTest {
     when(mockElement.getShadowCollection()).thenReturn(SHADOW_COLLECTION);
     when(mockElement.getDocumentId()).thenReturn(DOC_ID);
     when(mockElement.getTimestampDoc()).thenReturn(mockTimestampDocNewer);
-    when(mockElement.getDataDocument()).thenReturn(mockDataDoc);
+    when(mockElement.getDataAsJsonString()).thenReturn(mockDataDoc.toJson());
     when(mockElement.getShadowDocument()).thenReturn(mockShadowDocElement);
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenReturn(mockFindIterable);
 

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
@@ -127,4 +127,16 @@ public class UtilsTest {
 
     assertFalse(Utils.isNewerTimestamp(ts1, ts2));
   }
+
+  @Test
+  public void testJsonToDocument() {
+    String jsonString =
+        "{\"_id\":\"{\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"}\",\"data\":\"{\\\"_id\\\": {\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"},\\\"arrayField\\\": [\\\"hello\\\",10],\\\"dateField\\\": {\\\"$date\\\": 1565546054692},\\\"dateBefore1970\\\": {\\\"$date\\\": -1577923200000},\\\"decimal128Field\\\": {\\\"$numberDecimal\\\": \\\"10.99\\\"},\\\"documentField\\\": {\\\"a\\\": \\\"hello\\\"},\\\"doubleField\\\": 10.5,\\\"infiniteNumber\\\": Infinity,\\\"int32field\\\": 10,\\\"int64Field\\\": {\\\"$numberLong\\\": \\\"50\\\"},\\\"minKeyField\\\": {\\\"$minKey\\\": 1},\\\"maxKeyField\\\": {\\\"$maxKey\\\": 1},\\\"regexField\\\": {\\\"$regex\\\": \\\"^H\\\",\\\"$options\\\": \\\"i\\\"},\\\"timestampField\\\": {\\\"$timestamp\\\": {\\\"t\\\": 1565545664,\\\"i\\\": 1}},\\\"uuid\\\": {\\\"$binary\\\": \\\"OyQRAeK7QlWMr0E2xWapYg==\\\",\\\"$type\\\": \\\"04\\\"}}\",\"_metadata_stream\":\"extended-types-test\",\"_metadata_timestamp\":1745957556,\"_metadata_read_timestamp\":1745957556,\"_metadata_dataflow_timestamp\":1745963670,\"_metadata_read_method\":\"backfill\",\"_metadata_source_type\":\"backfill\",\"_metadata_deleted\":false,\"_metadata_table\":null,\"_metadata_change_type\":\"READ\",\"_metadata_primary_keys\":null,\"_metadata_uuid\":\"2a9cf8eb-4f35-433c-899a-39921d4c8587\",\"_metadata_timestamp_seconds\":\"1745957556\",\"_metadata_timestamp_nanos\":\"184498000\",\"_metadata_source\":{\"database\":\"extended_types\",\"collection\":\"mycol\",\"change_type\":\"READ\",\"is_deleted\":false,\"primary_key\":[\"_id\"]},\"_metadata_error\":null,\"_metadata_retry_count\":116}";
+    Document result = Utils.jsonToDocument(jsonString, 1L);
+    assertTrue(
+        result
+            .toJson()
+            .equals(
+                "{\"_id\": 1, \"arrayField\": [\"hello\", 10], \"dateField\": {\"$date\": \"2019-08-11T17:54:14.692Z\"}, \"dateBefore1970\": {\"$date\": {\"$numberLong\": \"-1577923200000\"}}, \"decimal128Field\": {\"$numberDecimal\": \"10.99\"}, \"documentField\": {\"a\": \"hello\"}, \"doubleField\": 10.5, \"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}, \"int32field\": 10, \"int64Field\": 50, \"minKeyField\": {\"$minKey\": 1}, \"maxKeyField\": {\"$maxKey\": 1}, \"regexField\": {\"$regularExpression\": {\"pattern\": \"^H\", \"options\": \"i\"}}, \"timestampField\": {\"$timestamp\": {\"t\": 1565545664, \"i\": 1}}, \"uuid\": {\"$binary\": {\"base64\": \"OyQRAeK7QlWMr0E2xWapYg==\", \"subType\": \"04\"}}}"));
+  }
 }


### PR DESCRIPTION
Moves the document construction to later in the stack so that the extended json string will be used while serialization is needed in the pipeline. Added support for UUID.