### PR TITLE
Integrate dlq retry count with the MongoDbChangeEventContext

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -876,8 +876,8 @@ public class DataStreamMongoDBToFirestore {
         .apply(
             "Write Failed Json To DLQ",
             DLQWriteTransform.WriteDLQ.newBuilder()
-                .withDlqDirectory(dlqManager.getRetryDlqDirectoryWithDateTime())
-                .withTmpDirectory(options.getDeadLetterQueueDirectory() + "/tmp_retry_json/")
+                .withDlqDirectory(dlqManager.getSevereDlqDirectoryWithDateTime())
+                .withTmpDirectory(options.getDeadLetterQueueDirectory() + "/tmp_non_retry_json/")
                 .setIncludePaneInfo(true)
                 .build());
     LOG.info("DLQ setup completed for failed JSON processing");

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/DatastreamConstants.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/DatastreamConstants.java
@@ -23,6 +23,7 @@ public class DatastreamConstants {
   public static final String EVENT_CHANGE_TYPE_KEY = "_metadata_change_type";
   public static final String TIMESTAMP_SECONDS = "_metadata_timestamp_seconds";
   public static final String TIMESTAMP_NANOS = "_metadata_timestamp_nanos";
+  public static final String RETRY_COUNT = "_metadata_retry_count";
   public static final String CHANGE_EVENT = "changeEvent";
   // DLQ related event field
   public static final String IS_DLQ_RECONSUMED = "isDlqReconsumed";

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
@@ -49,6 +49,7 @@ public class MongoDbEventDeadLetterQueueSanitizer
       jsonNode.putPOJO("documentId", input.getDocumentId());
       jsonNode.put("isDeleteEvent", input.isDeleteEvent());
       jsonNode.put(DatastreamConstants.IS_DLQ_RECONSUMED, true);
+      jsonNode.put(DatastreamConstants.RETRY_COUNT, input.getRetryCount() + 1);
 
       return OBJECT_MAPPER.writeValueAsString(jsonNode);
     } catch (JsonProcessingException e) {

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
@@ -396,7 +396,8 @@ public class MongoDbChangeEventContextTest {
             + "\"documentId\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},"
             + "\"isDeleteEvent\":false,"
             + "\"timestamp\":{\"seconds\":1683782270,\"nanos\":123456789},"
-            + "\"isDlqReconsumed\":false}";
+            + "\"isDlqReconsumed\":false,"
+            + "\"_metadata_retry_count\":0}";
 
     assertEquals(jsonString, expectedJson);
   }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
@@ -57,7 +57,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
             + "\"shadowCollection\":\"shadow_test_collection\","
             + "\"documentId\":\"test_id\","
             + "\"isDeleteEvent\":false,"
-            + "\"isDlqReconsumed\":true}";
+            + "\"isDlqReconsumed\":true,"
+            + "\"_metadata_retry_count\":1}";
     assertEquals(expectedJson, sanitizer.getJsonMessage(mockContext));
   }
 
@@ -72,7 +73,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
             + "\"shadowCollection\":\"shadow_test_collection\","
             + "\"documentId\":\"test_id\","
             + "\"isDeleteEvent\":false,"
-            + "\"isDlqReconsumed\":true}";
+            + "\"isDlqReconsumed\":true,"
+            + "\"_metadata_retry_count\":1}";
     assertEquals(expectedJson, sanitizer.getJsonMessage(mockContext));
   }
 
@@ -108,7 +110,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
             + "\"shadowCollection\":\"shadow_test_collection\","
             + "\"documentId\":\"test_id\","
             + "\"isDeleteEvent\":false,"
-            + "\"isDlqReconsumed\":true}";
+            + "\"isDlqReconsumed\":true,"
+            + "\"_metadata_retry_count\":1}";
     assertEquals(expectedJson, sanitizer.getJsonMessage(mockContext));
   }
 
@@ -122,5 +125,20 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
             + "\"documentId\":123,"
             + "\"collection\":\"another_collection\"}";
     assertEquals(expectedJson, sanitizer.getErrorMessageJson(mockContext));
+  }
+
+  @Test
+  public void testRetryCountIncrements() throws Exception {
+    when(mockContext.getRetryCount()).thenReturn(123);
+
+    String expectedJson =
+        "{\"changeEvent\":{\"key\":\"value\"},"
+            + "\"dataCollection\":\"test_collection\","
+            + "\"shadowCollection\":\"shadow_test_collection\","
+            + "\"documentId\":\"test_id\","
+            + "\"isDeleteEvent\":false,"
+            + "\"isDlqReconsumed\":true,"
+            + "\"_metadata_retry_count\":124}";
+    assertEquals(expectedJson, sanitizer.getJsonMessage(mockContext));
   }
 }


### PR DESCRIPTION
And set failed json parsing as non-retriable error.